### PR TITLE
Integrate FireAndForget library with Koin DI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,8 @@ dependencies {
   implementation(libs.kotlinx.collections.immutable)
   implementation(libs.multiplatform.settings)
   implementation(libs.multiplatform.settings.no.arg)
+  implementation(libs.fireandforget.core)
+  implementation(libs.fireandforget.multiplatform.settings)
   implementation(libs.alorma.settings.ui.tiles)
   implementation(libs.alorma.settings.ui.tiles.extended)
   implementation(libs.alorma.settings.ui.tiles.expressive)

--- a/app/src/main/kotlin/com/alorma/caducity/di/AppModule.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/di/AppModule.kt
@@ -38,6 +38,7 @@ val appModule = module {
   includes(themeModule)
   includes(dataModule)
   includes(domainModule)
+  includes(fireAndForgetModule)
 
   single { Settings() }
 

--- a/app/src/main/kotlin/com/alorma/caducity/di/FireAndForgetModule.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/di/FireAndForgetModule.kt
@@ -1,0 +1,13 @@
+package com.alorma.caducity.di
+
+import com.alorma.fireandforget.FireAndForgetRunner
+import com.alorma.fireandforget.mukltiplatform.settings.SettingsFireAndForgetRunner
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val fireAndForgetModule = module {
+  singleOf(::SettingsFireAndForgetRunner) {
+    bind<FireAndForgetRunner>()
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ room = "2.8.4"
 uiTiles = "2.23.0"
 koin = "4.1.1"
 kalendar = "2.9.0"
+fireandforget = "1.0.0"
 
 materialKolor = "5.0.0-alpha04"
 
@@ -64,6 +65,9 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 multiplatform-settings = { group = "com.russhwolf", name = "multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-no-arg = { group = "com.russhwolf", name = "multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }
+
+fireandforget-core = { group = "com.github.alorma.fire-and-forget", name = "core", version.ref = "fireandforget" }
+fireandforget-multiplatform-settings = { group = "com.github.alorma.fire-and-forget", name = "multiplatform-settings", version.ref = "fireandforget" }
 
 alorma-settings-ui-base = { group = "com.github.alorma.compose-settings", name = "ui-base", version.ref = "uiTiles" }
 alorma-settings-ui-tiles = { group = "com.github.alorma.compose-settings", name = "ui-tiles", version.ref = "uiTiles" }


### PR DESCRIPTION
## Summary

Integrates the FireAndForget library (v1.0.0) with Koin dependency injection to enable one-time operation flags for features like onboarding flows, feature announcements, and first-run setups.

## Changes

- ✅ Added FireAndForget dependencies to `gradle/libs.versions.toml`
- ✅ Added library imports to `app/build.gradle.kts`
- ✅ Created `FireAndForgetModule.kt` with `SettingsFireAndForgetRunner` configuration
- ✅ Registered module in Koin DI setup (`AppModule.kt`)
- ✅ Configured runner to use existing `multiplatform-settings` for state persistence

## Technical Details

- **Version**: 1.0.0
- **Artifact**: `com.github.alorma.fire-and-forget:core` and `multiplatform-settings`
- **DI Pattern**: Singleton `SettingsFireAndForgetRunner` bound to `FireAndForgetRunner` interface
- **Persistence**: Uses existing `multiplatform-settings` (SharedPreferences on Android)

## Usage Example

```kotlin
// Define a flag
class OnboardingFlag(runner: FireAndForgetRunner) : FireAndForget(
  fireAndForgetRunner = runner,
  name = "user_onboarding",
  defaultValue = true
)

// In ViewModel
class DashboardViewModel(
  private val runner: FireAndForgetRunner,
) : ViewModel() {
  private val onboardingFlag = OnboardingFlag(runner)

  fun checkOnboarding() {
    if (onboardingFlag.isEnabled()) {
      // Show onboarding
      onboardingFlag.disable()
    }
  }
}
```

## Test Plan

- [x] Build succeeds: `./gradlew assembleDebug`
- [x] Koin module loads without errors
- [x] Dependencies resolve correctly from Maven Central

## Future Use Cases

This infrastructure enables:
- First-time user onboarding tutorials
- "What's new" announcements for version updates
- Feature discovery tooltips
- Initial app setup flags
- Settings screen "Reset tutorials" functionality

Resolves #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)