### PR TITLE
feat(settings): hide AI Model settings when AI feature is disabled

### DIFF
--- a/app/src/main/kotlin/com/alorma/caducity/ui/screen/settings/SettingsRootScreen.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/ui/screen/settings/SettingsRootScreen.kt
@@ -22,6 +22,8 @@ import com.alorma.caducity.base.ui.icons.Palette
 import com.alorma.caducity.base.ui.icons.outlined.Settings
 import com.alorma.caducity.base.ui.icons.outlined.Shield
 import com.alorma.caducity.base.ui.icons.outlined.Sparkle
+import com.alorma.caducity.config.remoteconfig.rememberRemoteConfig
+import com.alorma.caducity.feature.ai.AiFeatureConfig
 import com.alorma.caducity.feature.tracking.SettingsScreen
 import com.alorma.caducity.feature.tracking.TrackScreen
 import com.alorma.caducity.ui.components.responsive.ResponsiveSettingsContainer
@@ -45,8 +47,10 @@ fun SettingsRootScreen(
   modifier: Modifier = Modifier,
 ) {
   TrackScreen(screen = SettingsScreen())
+  val aiModelEnabled = rememberRemoteConfig<AiFeatureConfig>().isEnabled()
   SettingsRootContent(
     isDebug = isDebug,
+    aiModelEnabled = aiModelEnabled,
     onNavigateToAppearance = onNavigateToAppearance,
     onNavigateToNotifications = onNavigateToNotifications,
     onNavigateToPrivacy = onNavigateToPrivacy,
@@ -61,6 +65,7 @@ fun SettingsRootScreen(
 @Composable
 private fun SettingsRootContent(
   isDebug: Boolean,
+  aiModelEnabled: Boolean,
   onNavigateToAppearance: () -> Unit,
   onNavigateToNotifications: () -> Unit,
   onNavigateToPrivacy: () -> Unit,
@@ -176,23 +181,25 @@ private fun SettingsRootContent(
           }
         }
 
-        // Group: AI Model
-        item {
-          StyledSettingsGroup(
-            title = { Text(stringResource(R.string.settings_ai_model_title)) },
-          ) {
-            StyledSettingsCard(
-              icon = {
-                Icon(
-                  imageVector = AppIcons.Outlined.Sparkle,
-                  contentDescription = null,
-                )
-              },
-              title = stringResource(R.string.settings_ai_model_title),
-              subtitle = stringResource(R.string.settings_ai_model_description),
-              onClick = onNavigateToAiModel,
-              shapes = ListItemDefaults.shapes(),
-            )
+        // Group: AI Model (only shown when the AI feature is enabled via remote config)
+        if (aiModelEnabled) {
+          item {
+            StyledSettingsGroup(
+              title = { Text(stringResource(R.string.settings_ai_model_title)) },
+            ) {
+              StyledSettingsCard(
+                icon = {
+                  Icon(
+                    imageVector = AppIcons.Outlined.Sparkle,
+                    contentDescription = null,
+                  )
+                },
+                title = stringResource(R.string.settings_ai_model_title),
+                subtitle = stringResource(R.string.settings_ai_model_description),
+                onClick = onNavigateToAiModel,
+                shapes = ListItemDefaults.shapes(),
+              )
+            }
           }
         }
 
@@ -228,6 +235,7 @@ fun SettingsScreenPreview() {
     Surface {
       SettingsRootContent(
         isDebug = true,
+        aiModelEnabled = true,
         onNavigateToAppearance = {},
         onNavigateToNotifications = {},
         onNavigateToPrivacy = {},


### PR DESCRIPTION
## What

The **AI Model** settings group was always rendered in the settings screen, even when the AI feature is turned off through remote config. This gates it behind the `ai_assistant_enabled` remote config so the setting only appears when the AI feature is enabled.

## Why

The dashboard already hides the AI assistant entry point when the flag is disabled (`aiFeatureConfig.isEnabled()`), but the settings entry did not follow the same rule, so users could still reach the AI model screen with the feature off. This makes the behaviour consistent across the app.

## How

- `SettingsRootScreen` reads `rememberRemoteConfig<AiFeatureConfig>().isEnabled()` and passes it down as an `aiModelEnabled` flag — the same pattern already used for `isDebug`, which keeps `SettingsRootContent` preview-friendly (no Koin lookup inside the previewed composable).
- The "AI Model" group is only emitted when `aiModelEnabled` is `true`.
- The preview passes `aiModelEnabled = true`.

With the default `ai_assistant_enabled = false`, neither the dashboard assistant nor the settings model entry is shown.

## Testing

Not built locally (no Android SDK in this environment). Verified imports, import ordering, line length (ktlint, 120), and that the `rememberRemoteConfig` / `isEnabled()` API matches existing usage in `DashboardScreen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ES7LXgZPRxjRY6Qx9R63t

---
_Generated by [Claude Code](https://claude.ai/code/session_016ES7LXgZPRxjRY6Qx9R63t)_