### PR TITLE
feat(ai): make grocery parsing more robust and show raw error in debug

### DIFF
--- a/app/src/main/kotlin/com/alorma/caducity/feature/ai/GroceryParseResult.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/feature/ai/GroceryParseResult.kt
@@ -18,6 +18,13 @@ sealed interface GroceryParseResult {
   /** The on-device model has not finished downloading yet. */
   data object ModelNotReady : GroceryParseResult
 
-  /** Generation or response parsing failed unexpectedly. */
-  data object Failed : GroceryParseResult
+  /**
+   * Generation or response parsing failed unexpectedly.
+   *
+   * [debugDetail] carries the raw model output (or error message) for
+   * diagnostics; it is only surfaced in the UI on debug builds.
+   */
+  data class Failed(
+    val debugDetail: String? = null,
+  ) : GroceryParseResult
 }

--- a/app/src/main/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParser.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParser.kt
@@ -47,12 +47,12 @@ class LlamatikGroceryParser(
           Timber.tag(TAG).d("RAW RESPONSE:\n%s", raw)
 
           when (val parsed = parseProposals(raw)) {
-            null -> GroceryParseResult.Failed
+            null -> GroceryParseResult.Failed(debugDetail = raw)
             else -> if (parsed.isEmpty()) GroceryParseResult.NoGroceriesFound else GroceryParseResult.Success(parsed)
           }
         } catch (e: Exception) {
           Timber.tag(TAG).e(e, "Grocery parsing failed")
-          GroceryParseResult.Failed
+          GroceryParseResult.Failed(debugDetail = e.message ?: e::class.simpleName)
         }
       }
     }
@@ -76,7 +76,9 @@ class LlamatikGroceryParser(
       maxTokens = 512,
       topP = 0.9f,
       topK = 40,
-      repeatPenalty = 1.3f,
+      // JSON repeats structural tokens ({ } " , field names) heavily, so keep the
+      // repeat penalty low — a high value pushes small models to emit malformed JSON.
+      repeatPenalty = 1.1f,
       contextLength = 2048,
       numThreads = Runtime.getRuntime().availableProcessors().coerceAtMost(4),
       useMmap = true,
@@ -94,33 +96,39 @@ class LlamatikGroceryParser(
     /**
      * Extracts grocery proposals from the model's raw output.
      *
-     * Returns `null` when the response could not be parsed as a JSON array (a
-     * genuine failure), and an empty list when the model correctly reported no
-     * groceries (`[]`).
+     * Returns `null` when the response contained no parseable JSON (a genuine
+     * failure), and an empty list when the model correctly reported no
+     * groceries (`[]`). Accepts either a JSON array or a single bare object, so
+     * a model that forgets the array brackets still yields a proposal.
      */
     fun parseProposals(raw: String): List<GroceryProposal>? =
       try {
-        val start = raw.indexOf('[')
-        val end = raw.lastIndexOf(']')
-        if (start == -1 || end == -1 || end <= start) {
-          null
-        } else {
-          val arrayJson = raw.substring(start, end + 1)
-          json
-            .parseToJsonElement(arrayJson)
-            .jsonArray
-            .map { element ->
-              val obj = element.jsonObject
-              GroceryProposal(
-                productName = obj["product_name"]?.jsonPrimitive?.content.orEmpty(),
-                quantity = obj["quantity"]?.jsonPrimitive?.content?.toIntOrNull() ?: 1,
-                category = obj["category"]?.jsonPrimitive?.content.orEmpty(),
-              )
-            }.filter { it.productName.isNotBlank() }
-        }
+        val elements =
+          extractBracketed(raw, '[', ']')?.let { json.parseToJsonElement(it).jsonArray }
+            ?: extractBracketed(raw, '{', '}')?.let { listOf(json.parseToJsonElement(it)) }
+        elements
+          ?.map { element ->
+            val obj = element.jsonObject
+            GroceryProposal(
+              productName = obj["product_name"]?.jsonPrimitive?.content.orEmpty(),
+              quantity = obj["quantity"]?.jsonPrimitive?.content?.toIntOrNull() ?: 1,
+              category = obj["category"]?.jsonPrimitive?.content.orEmpty(),
+            )
+          }?.filter { it.productName.isNotBlank() }
       } catch (_: Exception) {
         null
       }
+
+    /** Returns the substring from the first [open] to the last [close], or null if absent. */
+    private fun extractBracketed(
+      raw: String,
+      open: Char,
+      close: Char,
+    ): String? {
+      val start = raw.indexOf(open)
+      val end = raw.lastIndexOf(close)
+      return if (start == -1 || end == -1 || end <= start) null else raw.substring(start, end + 1)
+    }
 
     fun buildGemma3Prompt(
       system: String,
@@ -149,16 +157,20 @@ class LlamatikGroceryParser(
         }
       return """
         You are a grocery expiration tracker assistant.
-        The user will describe groceries they bought, including quantity.
+        The user will describe groceries they bought, possibly with quantities.
+        The input may mention expiration or purchase dates — IGNORE any dates, extract only products.
         The user's language is $languageName. Write product_name and category values in $languageName.
         Extract each distinct product and return ONLY a JSON array. No markdown, no prose, no code fences.
         Rules:
         - If the input contains no grocery products, return exactly: []
         - Output EXACTLY ONE object per distinct product.
         - Every object MUST have all three fields: product_name, category, quantity.
-        - quantity is the total number of individual units mentioned.
+        - quantity is the total number of individual units mentioned (default to 1 if unspecified).
         - Choose ONE category per product.
         $categoryInstruction
+
+        Example input: "2 strawberry yogurts and a liter of milk"
+        Example output: [{"product_name":"Strawberry yogurt","category":"Dairy","quantity":2},{"product_name":"Milk","category":"Dairy","quantity":1}]
         """.trimIndent()
     }
   }

--- a/app/src/main/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParser.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParser.kt
@@ -134,11 +134,14 @@ class LlamatikGroceryParser(
       system: String,
       userInput: String,
     ): String =
+      // Gemma has no dedicated system role — only user/model turns. The
+      // instructions must be folded into the first user turn; emitting a
+      // <start_of_turn>system block the model was never trained on makes it
+      // ignore the instructions and reply conversationally instead.
       buildString {
-        append("<start_of_turn>system\n")
-        append(system.trim())
-        append("\n<end_of_turn>\n")
         append("<start_of_turn>user\n")
+        append(system.trim())
+        append("\n\n")
         append(userInput.trim())
         append("\n<end_of_turn>\n")
         append("<start_of_turn>model\n")

--- a/app/src/main/kotlin/com/alorma/caducity/ui/screen/ai/AiAssistantScreen.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/ui/screen/ai/AiAssistantScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -170,7 +171,7 @@ fun AiAssistantScreen(
                     onAction = { viewModel.onProposalAction(it) },
                   )
                 ChatMessage.Thinking -> ThinkingBubble()
-                is ChatMessage.Error -> IncomingErrorBubble(message.reason)
+                is ChatMessage.Error -> IncomingErrorBubble(message.reason, message.debugDetail)
               }
             }
           }
@@ -369,7 +370,10 @@ private fun ThinkingBubble() {
 }
 
 @Composable
-private fun IncomingErrorBubble(reason: ChatMessage.Error.Reason) {
+private fun IncomingErrorBubble(
+  reason: ChatMessage.Error.Reason,
+  debugDetail: String?,
+) {
   val messageRes =
     when (reason) {
       ChatMessage.Error.Reason.NoGroceries -> R.string.ai_error_no_groceries
@@ -380,16 +384,29 @@ private fun IncomingErrorBubble(reason: ChatMessage.Error.Reason) {
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.Start,
   ) {
-    Text(
-      text = stringResource(messageRes),
+    Column(
       modifier =
         Modifier
           .widthIn(max = 280.dp)
           .clip(MaterialTheme.shapes.large)
           .background(MaterialTheme.colorScheme.errorContainer)
           .padding(horizontal = 16.dp, vertical = 10.dp),
-      color = MaterialTheme.colorScheme.onErrorContainer,
-      style = MaterialTheme.typography.bodyMedium,
-    )
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      Text(
+        text = stringResource(messageRes),
+        color = MaterialTheme.colorScheme.onErrorContainer,
+        style = MaterialTheme.typography.bodyMedium,
+      )
+      // Debug-only: the raw model output, surfaced by the ViewModel only on debug builds.
+      if (debugDetail != null) {
+        Text(
+          text = stringResource(R.string.ai_error_debug_detail, debugDetail),
+          color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f),
+          style = MaterialTheme.typography.labelSmall,
+          fontFamily = FontFamily.Monospace,
+        )
+      }
+    }
   }
 }

--- a/app/src/main/kotlin/com/alorma/caducity/ui/screen/ai/AiAssistantViewModel.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/ui/screen/ai/AiAssistantViewModel.kt
@@ -9,6 +9,7 @@ import com.alorma.caducity.feature.ai.GroceryParseResult
 import com.alorma.caducity.feature.ai.ModelDownloadState
 import com.alorma.caducity.feature.ai.ModelManager
 import com.alorma.caducity.feature.ai.priority
+import com.alorma.caducity.feature.debug.DebugModeProvider
 import com.alorma.caducity.ui.base.BaseViewModel
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
@@ -30,6 +31,7 @@ class AiAssistantViewModel(
   private val productMatcher: AiProductMatcher,
   private val categoryDataSource: CategoryDataSource,
   private val commitProposalUseCase: CommitProposalUseCase,
+  private val debugModeProvider: DebugModeProvider,
 ) : BaseViewModel<AiAssistantNavigation, AiAssistantNavigationSideEffect, AiAssistantSideEffect>() {
   val modelState: StateFlow<ModelDownloadState> =
     modelManager
@@ -80,7 +82,11 @@ class AiAssistantViewModel(
           }
           GroceryParseResult.NoGroceriesFound -> ChatMessage.Error(ChatMessage.Error.Reason.NoGroceries)
           GroceryParseResult.ModelNotReady -> ChatMessage.Error(ChatMessage.Error.Reason.ModelNotReady)
-          GroceryParseResult.Failed -> ChatMessage.Error(ChatMessage.Error.Reason.Failed)
+          is GroceryParseResult.Failed ->
+            ChatMessage.Error(
+              reason = ChatMessage.Error.Reason.Failed,
+              debugDetail = result.debugDetail?.takeIf { debugModeProvider.isDebugMode() },
+            )
         }
 
       _messages.update { messages ->

--- a/app/src/main/kotlin/com/alorma/caducity/ui/screen/ai/ChatMessage.kt
+++ b/app/src/main/kotlin/com/alorma/caducity/ui/screen/ai/ChatMessage.kt
@@ -13,6 +13,7 @@ sealed interface ChatMessage {
 
   data class Error(
     val reason: Reason,
+    val debugDetail: String? = null,
   ) : ChatMessage {
     enum class Reason {
       /** The model ran but found no grocery products in the message. */

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -69,7 +69,7 @@
   <string name="ai_proposal_add">Afegir a %1$s</string>
   <string name="ai_proposal_add_to_category">Afegir a %1$s</string>
   <string name="ai_proposal_create">Crear a %1$s</string>
-  <string name="ai_parse_error">No he entès això. Intenta descriure el producte i la data de caducitat amb més detall.</string>
+  <string name="ai_parse_error">No he entès això. Prova de reformular-ho indicant els productes i les quantitats que has comprat.</string>
   <string name="ai_error_no_groceries">No he trobat cap aliment en això. Prova d\'indicar els productes i les quantitats que has comprat.</string>
   <string name="ai_error_model_not_ready">El model d\'IA encara no està a punt. Espera que acabi la descàrrega i torna-ho a intentar.</string>
   <string name="ai_commit_error">No s\'ha pogut afegir aquest producte. Torna-ho a intentar.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -68,7 +68,7 @@
   <string name="ai_proposal_add">Añadir a %1$s</string>
   <string name="ai_proposal_add_to_category">Añadir a %1$s</string>
   <string name="ai_proposal_create">Crear en %1$s</string>
-  <string name="ai_parse_error">No he entendido eso. Intenta describir el producto y la fecha de caducidad con más detalle.</string>
+  <string name="ai_parse_error">No he entendido eso. Prueba a reformularlo indicando los productos y las cantidades que compraste.</string>
   <string name="ai_error_no_groceries">No he encontrado ningún alimento en eso. Prueba a indicar los productos y las cantidades que compraste.</string>
   <string name="ai_error_model_not_ready">El modelo de IA aún no está listo. Espera a que termine la descarga e inténtalo de nuevo.</string>
   <string name="ai_commit_error">No se pudo añadir ese producto. Inténtalo de nuevo.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,10 +49,11 @@
   <string name="ai_proposal_add">Add to %1$s</string>
   <string name="ai_proposal_add_to_category">Add to %1$s</string>
   <string name="ai_proposal_create">Create in %1$s</string>
-  <string name="ai_parse_error">Sorry, I couldn\'t understand that. Try describing the product and expiration date more clearly.</string>
+  <string name="ai_parse_error">Sorry, I couldn\'t understand that. Try rephrasing with the products and quantities you bought.</string>
   <string name="ai_error_no_groceries">I couldn\'t find any groceries in that. Try naming the products and quantities you bought.</string>
   <string name="ai_error_model_not_ready">The AI model isn\'t ready yet. Please wait for the download to finish and try again.</string>
   <string name="ai_commit_error">Couldn\'t add that item. Please try again.</string>
+  <string name="ai_error_debug_detail" translatable="false">Debug — model output:\n%1$s</string>
   <string name="products_screen_title">Categories</string>
   <string name="dashboard_action_collapse">Collapse</string>
   <string name="dashboard_action_expand">Expand</string>

--- a/app/src/test/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParserTest.kt
+++ b/app/src/test/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParserTest.kt
@@ -67,6 +67,17 @@ class LlamatikGroceryParserTest {
   }
 
   @Test
+  fun `parseProposals accepts a single bare object without array brackets`() {
+    val raw = """{"product_name":"Milk","category":"Dairy","quantity":"2"}"""
+
+    val result = LlamatikGroceryParser.parseProposals(raw)
+
+    expectThat(result).isNotNull().hasSize(1)
+    expectThat(result?.first()?.productName).isEqualTo("Milk")
+    expectThat(result?.first()?.quantity).isEqualTo(2)
+  }
+
+  @Test
   fun `parseProposals returns empty list for an explicit empty array`() {
     expectThat(LlamatikGroceryParser.parseProposals("[]")).isNotNull().isEmpty()
   }
@@ -98,6 +109,15 @@ class LlamatikGroceryParserTest {
     val prompt = LlamatikGroceryParser.buildSystemPrompt(existingCategories = emptyList())
 
     expectThat(prompt).contains("infer an appropriate grocery category")
+  }
+
+  @Test
+  fun `buildSystemPrompt instructs the model to ignore dates and includes an example`() {
+    val prompt = LlamatikGroceryParser.buildSystemPrompt(existingCategories = emptyList())
+
+    expectThat(prompt)
+      .contains("IGNORE any dates")
+      .contains("Example output:")
   }
 
   @Test

--- a/app/src/test/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParserTest.kt
+++ b/app/src/test/kotlin/com/alorma/caducity/feature/ai/LlamatikGroceryParserTest.kt
@@ -134,14 +134,15 @@ class LlamatikGroceryParserTest {
   // ── buildGemma3Prompt ──────────────────────────────────────────────────
 
   @Test
-  fun `buildGemma3Prompt wraps system and user turns with Gemma tags`() {
+  fun `buildGemma3Prompt folds the system prompt into the user turn`() {
     val prompt = LlamatikGroceryParser.buildGemma3Prompt(system = "SYS", userInput = "2 milks")
 
     expectThat(prompt)
-      .contains("<start_of_turn>system")
-      .contains("SYS")
       .contains("<start_of_turn>user")
+      .contains("SYS")
       .contains("2 milks")
       .contains("<start_of_turn>model")
+    // Gemma has no system role — the instructions live inside the user turn.
+    expectThat(prompt).not().contains("<start_of_turn>system")
   }
 }


### PR DESCRIPTION
## What

The AI assistant returned a generic "couldn't understand that" error on reasonable input (e.g. _"Dos iogures de fresa, caducan en 4 días"_). This improves how robustly the on-device model's output is parsed, and makes failures diagnosable on debug builds.

## Parsing robustness

- **Lower `repeatPenalty` 1.3 → 1.1.** JSON output repeats structural tokens heavily (`{ } " ,` and the field names), and a high repeat penalty pushes small models (Gemma 270M/1B) toward malformed or truncated JSON. This was the most likely cause of the failure in the screenshot.
- **One-shot example + date handling in the prompt.** Small instruction-tuned models follow the output format much better with a concrete example. Also explicitly tell the model to ignore any dates in the input — the parser only extracts products; the expiration date is chosen afterward in the date picker.
- **Bare-object fallback.** If the model forgets the array brackets and emits a single `{…}` object, it's now accepted instead of failing.

## Error clarity

- Drop the misleading _"describe the expiration date more clearly"_ guidance from the parse-error copy (EN/ES/CA), since the parser never reads dates.
- **Debug-only raw output.** On debug builds the error bubble now shows the raw model output, wired through `GroceryParseResult.Failed(debugDetail)` and gated by the existing `DebugModeProvider` so it never leaks into release builds.

## Tests

- Cover the bare-object fallback and the new prompt instructions (ignore-dates, example present).

## Testing

Not built locally (no Android SDK in this environment). Verified imports/ordering, line length (ktlint, 120), exhaustiveness of the `when` over `GroceryParseResult`, and that `DebugModeProvider` is in the DI graph (`platformModule`). The `repeatPenalty` and prompt changes affect real model output, which can only be validated on a device — the debug error view added here is intended to make exactly that easier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ES7LXgZPRxjRY6Qx9R63t

---
_Generated by [Claude Code](https://claude.ai/code/session_016ES7LXgZPRxjRY6Qx9R63t)_